### PR TITLE
Install git dependency inside virtual machine.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,6 @@ The following instructions describe how to configure your system to build OpenWh
 The following are verified to work on Ubuntu 14.04.3 LTS. You may need `sudo` or root access to install required software depending on your system setup.
 
   ```
-  # install git if it is not installed
-  apt-get install git
-
   # clone openwhisk
   git clone https://github.com/openwhisk/openwhisk.git
 

--- a/tools/vagrant/Vagrantfile
+++ b/tools/vagrant/Vagrantfile
@@ -40,6 +40,7 @@ Vagrant.configure('2') do |config|
   config.vm.provision "fix-no-tty", type: "shell" do |s|
     s.privileged = false
     s.inline = "sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile"
+    s.inline = "sudo apt-get install -y git"
   end
 
   # If provisioning in shared mode, mount the file system, assuming ../../ is the openwhisk


### PR DESCRIPTION
In the Vagrant related instructions, first step is to have git installed.
Added git installation during Vagrant imagine provisioning, hence saving
this step in the instructions.

Also update README.md to reflect the change.